### PR TITLE
👷 Add PyPI publication to actions pipelines

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -26,3 +26,31 @@ jobs:
       run: docker push islasgeci/dummy_transformations:latest
     - name: Sube sha a Docker Hub
       run: docker push islasgeci/dummy_transformations:${GITHUB_SHA:0:4}
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+        skip_existing: true

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -28,7 +28,7 @@ jobs:
       run: docker push islasgeci/dummy_transformations:${GITHUB_SHA:0:4}
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: docker push islasgeci/dummy_transformations:${GITHUB_SHA:0:4}
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,31 @@ jobs:
       run: docker push islasgeci/dummy_transformations:stable
     - name: Sube sha a Docker Hub
       run: docker push islasgeci/dummy_transformations:${GITHUB_SHA:0:4}
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+        skip_existing: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,4 +17,33 @@ jobs:
     - name: Corre pruebas y evalúa cobertura
       run: docker run islasgeci make coverage
     - name: Evalúa resistencia a mutaciones
-      run: docker run islasgeci make mutants
+      run: docker run islasgeci make mutants      
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TOKEN_TEST }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       run: docker run islasgeci make mutants      
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9


### PR DESCRIPTION
First try to add automated PyPI publication for Python packages the actual set up works like:

* In every commit in a Pull Request, publish package to Test PyPI.
* In a push to `develop` or `main`, publish package to PyPI.